### PR TITLE
Issue 32298: Use gateway instead of ipaddr to check if a route is IPv6.

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -981,7 +981,8 @@ def build_routes(iface, **settings):
     opts6 = []
     opts4 = []
     for route in opts['routes']:
-        ipaddr = route['ipaddr']
+        # ipv6_addr doesn't like "::/0" (from an IPv6 default route), so use gateway if available.
+        ipaddr = route.get('gateway', route['ipaddr'])
         if salt.utils.validate.net.ipv6_addr(ipaddr):
             opts6.append(route)
         else:


### PR DESCRIPTION
### What does this PR do?

Allows configuring a static default IPv6 route (ipaddr=='::/0') on RedHat-derived systems by using gateway instead of ipaddr (if available) to determine IPv6 vs IPv4.

ipv6_addr() doesn't validate when netmask==0, which is the case with default routes.
### What issues does this PR fix or reference?

issue #32298
### Previous Behavior

IPv6 default routes were written into route-_interface_ instead of route6-_interface_.
### New Behavior

IPv6 default routes are written into route6-_interface_.
### Tests written?

No
